### PR TITLE
Disable maintainers lint

### DIFF
--- a/.github/workflows/lint-build.yaml
+++ b/.github/workflows/lint-build.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-dirs=. --charts=.
+        run: ct lint --chart-dirs=. --charts=. --validate-maintainers=false
 
   build:
     name: build


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The branch naming convention follows our guidelines
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR disable the maintainers linting that is done by checking if the name is a valid account in GitHub/GitLab/BitBucket, but in our case real names are being used instead of usernames.

* **What is the current behavior?** (You can also link to an open issue here)

The maintainers linting fails because the `maintainers.name` field is populated with full names instead of GitHub/GitLab/BitBucket usernames.

* **What is the new behavior (if this is a feature change)?**

The maintainers linting is disabled.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

None.
