### PR TITLE
Use Python logger for the JellySeerr init

### DIFF
--- a/config/jellyseerr/init-jellyseerr.py
+++ b/config/jellyseerr/init-jellyseerr.py
@@ -29,7 +29,6 @@ session = requests.Session()
 def make_get(endpoint=""):
 
     url = "{0}{1}".format(jellyseer_url, endpoint)
-    print("Using url =  {0}".format(str(url)))
 
     logger.debug(" ".join([
         url,
@@ -59,8 +58,6 @@ def make_get(endpoint=""):
 def make_post(endpoint="", body=None):
 
     url = "{0}{1}".format(jellyseer_url, endpoint)
-    print("Using url =  {0}".format(str(url)))
-    print("Using body =  {0}".format(str(body)))
 
     logger.debug(" ".join([
         url,
@@ -83,7 +80,7 @@ def make_post(endpoint="", body=None):
         "Response body:",
         response.text
     ]))
-    
+
     response.raise_for_status()
     try:
         return response.json()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The branch naming convention follows our guidelines
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR replaces Python prints with the logger in the JellySeer init script and adds the `JSONDecodeError` import that is missing.

* **What is the current behavior?** (You can also link to an open issue here)

Script log are written to the standard output via `print(str)`. Moreover, `JSONDecodeError` import is missing.

* **What is the new behavior (if this is a feature change)?**

Both `JSONDecodeError` import logger has been defined and used to log several things with different levels.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

None