### PR TITLE
Fix Unauthorized error when providing default credentials

### DIFF
--- a/servarr/README.md
+++ b/servarr/README.md
@@ -96,6 +96,7 @@ Servarr complete Helm Chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| qbittorrent.csrf_protection | bool | false | Whether to enable or disable CSRF Protection on qBitTorrent WebGUI |
 | torrent.password | string | No default value | password of the qBitTorrent admin user. Must be at least of 8 characters. |
 | torrent.username | string | No default value | username of the qBitTorrent admin user |
 

--- a/servarr/config/scripts/init-qbittorrent.py
+++ b/servarr/config/scripts/init-qbittorrent.py
@@ -47,7 +47,12 @@ General\Locale=en
 MailNotification\req_auth=true
 WebUI\HostHeaderValidation=false
 WebUI\LocalHostAuth=false
-
+{%- if .Values.qbittorrent.csrf_protection %}
+WebUI\CSRFProtection=false
+WebUI\ClickjackingProtection=false
+{%- else %}
+WebUI\Address={{ index .Values.qbittorrent.ingress "qbittorrent-ing" "hosts" 0 "host" }}
+{%- end %}
 WebUI\Password_PBKDF2="{{`{{ torrentPassword }}`}}"
 WebUI\UseUPnP=false
 WebUI\Username={{`{{ torrentUsername }}`}}

--- a/servarr/config/scripts/init-qbittorrent.py
+++ b/servarr/config/scripts/init-qbittorrent.py
@@ -50,7 +50,7 @@ WebUI\LocalHostAuth=false
 {{- if not (default .Values.qbittorrent.csrf_protection false) }}
 WebUI\CSRFProtection=false
 WebUI\ClickjackingProtection=false
-{{- else }}
+{{- end }}
 WebUI\Password_PBKDF2="{{`{{ torrentPassword }}`}}"
 WebUI\UseUPnP=false
 WebUI\Username={{`{{ torrentUsername }}`}}

--- a/servarr/config/scripts/init-qbittorrent.py
+++ b/servarr/config/scripts/init-qbittorrent.py
@@ -47,12 +47,10 @@ General\Locale=en
 MailNotification\req_auth=true
 WebUI\HostHeaderValidation=false
 WebUI\LocalHostAuth=false
-{%- if not .Values.qbittorrent.csrf_protection %}
+{{- if not (default .Values.qbittorrent.csrf_protection false) }}
 WebUI\CSRFProtection=false
 WebUI\ClickjackingProtection=false
-{%- else %}
-WebUI\Address={{ index .Values.qbittorrent.ingress "qbittorrent-ing" "hosts" 0 "host" }}
-{%- end %}
+{{- else }}
 WebUI\Password_PBKDF2="{{`{{ torrentPassword }}`}}"
 WebUI\UseUPnP=false
 WebUI\Username={{`{{ torrentUsername }}`}}

--- a/servarr/config/scripts/init-qbittorrent.py
+++ b/servarr/config/scripts/init-qbittorrent.py
@@ -47,7 +47,7 @@ General\Locale=en
 MailNotification\req_auth=true
 WebUI\HostHeaderValidation=false
 WebUI\LocalHostAuth=false
-{%- if .Values.qbittorrent.csrf_protection %}
+{%- if not .Values.qbittorrent.csrf_protection %}
 WebUI\CSRFProtection=false
 WebUI\ClickjackingProtection=false
 {%- else %}

--- a/servarr/values.yaml
+++ b/servarr/values.yaml
@@ -828,6 +828,10 @@ jellyseerr:
 
 # @ignore
 qbittorrent:
+  # -- Whether to enable or disable CSRF Protection on qBitTorrent WebGUI
+  # @section -- Torrent
+  # @default -- false
+  csrf_protection: false
   metrics:
     main:
       enabled: *metricsEnabled

--- a/servarr/values.yaml
+++ b/servarr/values.yaml
@@ -826,15 +826,16 @@ jellyseerr:
           main:
             mountPath: /mnt/media
 
-# @ignore
 qbittorrent:
   # -- Whether to enable or disable CSRF Protection on qBitTorrent WebGUI
   # @section -- Torrent
   # @default -- false
   csrf_protection: false
+  # @ignore
   metrics:
     main:
       enabled: *metricsEnabled
+  # @ignore
   workload:
     main:
       podSpec:
@@ -842,6 +843,7 @@ qbittorrent:
           main:
             env:
               QBITTORRENT__USE_PROFILE: true
+  # @ignore
   ingress:
     qbittorrent-ing:
       enabled: true
@@ -865,6 +867,7 @@ qbittorrent:
           enabled: false
         traefik:
           enabled: false
+  # @ignore
   persistence:
     config:
       enabled: true


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The branch naming convention follows our guidelines
- [X] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix Unauthorized error when logging in qBitTorrent WEB GUI using Firefox or other affected browsers.
Cause is referenced [here](https://github.com/guillaumedsde/alpine-qbittorrent-openvpn/issues/42#issuecomment-744041612). 

* **What is the current behavior?** (You can also link to an open issue here)
When setting non default credentials and using Firefox as browser (others may be affected too), we face an `Unauthorized` error after login.

* **What is the new behavior (if this is a feature change)?**

If the error occurs, simply set the flag `qbittorrent.csrf_protection` to false and redeploy (no upgrade supported so far).
In this way, users should be able to login on the WebGUI.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No braking change, since the default settings (if users do not update their own value file) will disable CSRF Protection by default.

* **Other information**:

Closes #27 

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/fonzdm/servarr/CONTRIBUTING.md) -->
