### PR TITLE
Add the Helm Chart post installation notes

### DIFF
--- a/servarr/templates/NOTES.txt
+++ b/servarr/templates/NOTES.txt
@@ -2,3 +2,9 @@ Chart Details:
   Name:          {{ .Chart.Name }}
   Chart Version: {{ .Chart.Version }}
   App Version:   {{ .Chart.AppVersion }}
+
+Deployment Info:
+  Namespace:     {{ .Release.Namespace }}
+  Release Name:  {{ .Release.Name }}
+
+** Please be patient while the chart is being deployed **

--- a/servarr/templates/NOTES.txt
+++ b/servarr/templates/NOTES.txt
@@ -8,3 +8,8 @@ Deployment Info:
   Release Name:  {{ .Release.Name }}
 
 ** Please be patient while the chart is being deployed **
+
+Get more information about the deployment:
+  $ helm status -n {{ .Release.Namespace }} {{ .Release.Name }}
+  $ helm get all -n {{ .Release.Namespace }} {{ .Release.Name }}
+  $ helm get values -n {{ .Release.Namespace }} {{ .Release.Name }} -a

--- a/servarr/templates/NOTES.txt
+++ b/servarr/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Chart Details:
+  Name:          {{ .Chart.Name }}
+  Chart Version: {{ .Chart.Version }}
+  App Version:   {{ .Chart.AppVersion }}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The branch naming convention follows our guidelines
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds some post installation notes when the `helm install` command is successful.

* **What is the current behavior?** (You can also link to an open issue here)

There isn't anything shared with the end-user when the Helm command exits, and that's an issue since most of the time the resources creation will still be on going while the `helm install` terminated successfully.

* **What is the new behavior (if this is a feature change)?**

Some notes are being shown when `helm install` terminates successfully, telling the end user to be patient and wait for `servarr` to be fully deployed. There are listed some information, such as:

- Chart details:
  - Name
  - Version
  - App version
- Namespace and Release Name
- Useful Helm commands to check the deployment status:
  - `helm status -n {{ .Release.Namespace }} {{ .Release.Name }}`
  - `helm get all -n {{ .Release.Namespace }} {{ .Release.Name }}`
  - `helm get values -n {{ .Release.Namespace }} {{ .Release.Name }} -a`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

None
