### PR TITLE
Add `global.ingressClassName` anchor without default value

### DIFF
--- a/.github/ci/ci-values.yaml
+++ b/.github/ci/ci-values.yaml
@@ -1,6 +1,7 @@
 global:
   apikey: &apikey "gs12345678fc4923f1dm45b5a71098s2"
   storageClassName: &storageClassName "longhorn"
+    ingressClassName: &ingressClassName "nginx"
   certManagerClusterIssuer: &issuer "letsencrypt-cloudflare"
 
 metrics:
@@ -17,6 +18,8 @@ dash:
   username: admin
   password: str0ngP4ssw0rd.
   mail: admin@gmail.com
+  countryCode: "US"
+  preferredLanguage: "en"
 
 torrent:
   username: admin
@@ -254,7 +257,7 @@ issuer:
   server: https://acme-v02.api.letsencrypt.org/directory
   email: admin@gmail.com
   secretName: letsencrypt-prod
-  ingressClassName: nginx
+  ingressClassName: *ingressClassName
   cloudFlareKey: wda9d2W_p290dkawWEo102kl1plWpo123l
 
 volumes:
@@ -288,7 +291,7 @@ sonarr:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: sonarr.media.local
           paths:
@@ -354,7 +357,7 @@ radarr:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: radarr.media.local
           paths:
@@ -447,7 +450,7 @@ jellyfin:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: jellyfin.media.local
           paths:
@@ -533,7 +536,7 @@ jellyseerr:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: jellyseerr.media.local
           paths:
@@ -572,8 +575,8 @@ jellyseerr:
           main:
             mountPath: /mnt/media
 
-# $QBITTORRENT__USE_PROFILE
 qbittorrent:
+  csrf_protection: false
   metrics:
     main:
       enabled: *metricsEnabled
@@ -592,7 +595,7 @@ qbittorrent:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: torrent.media.local
           paths:
@@ -648,7 +651,7 @@ prowlarr:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: prowlarr.media.local
           paths:

--- a/.github/ci/ci-values.yaml
+++ b/.github/ci/ci-values.yaml
@@ -1,7 +1,7 @@
 global:
   apikey: &apikey "gs12345678fc4923f1dm45b5a71098s2"
   storageClassName: &storageClassName "longhorn"
-    ingressClassName: &ingressClassName "nginx"
+  ingressClassName: &ingressClassName "nginx"
   certManagerClusterIssuer: &issuer "letsencrypt-cloudflare"
 
 metrics:

--- a/servarr/README.md
+++ b/servarr/README.md
@@ -62,7 +62,7 @@ Servarr complete Helm Chart for Kubernetes
 |-----|------|---------|-------------|
 | global.apikey | string | No default value is configured for security reasons | Insert your Prowlarr, Sonarr, Radarr API key here (one to rule them all!). Do not remove the `&apikey` anchor! |
 | global.certManagerClusterIssuer | string | No default value, leave empty if not required | Insert your cert manager cluster issuer, e.g.: letsencrypt-cloudflare. Do not remove the `&issuer` anchor! |
-| global.ingressClassName | string | No default value, leave empty to use the default Ingress Class. | Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor! |
+| global.ingressClassName | string | nginx | Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor! |
 | global.storageClassName | string | `"network-block"` | Insert your storage class here, e.g.: &storageClassName network-block. Do not remove the `&storageClassName` anchor! |
 
 ### Prowlarr

--- a/servarr/README.md
+++ b/servarr/README.md
@@ -62,6 +62,7 @@ Servarr complete Helm Chart for Kubernetes
 |-----|------|---------|-------------|
 | global.apikey | string | No default value is configured for security reasons | Insert your Prowlarr, Sonarr, Radarr API key here (one to rule them all!). Do not remove the `&apikey` anchor! |
 | global.certManagerClusterIssuer | string | No default value, leave empty if not required | Insert your cert manager cluster issuer, e.g.: letsencrypt-cloudflare. Do not remove the `&issuer` anchor! |
+| global.ingressClassName | string | No default value, leave empty to use the default Ingress Class. | Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor! |
 | global.storageClassName | string | `"network-block"` | Insert your storage class here, e.g.: &storageClassName network-block. Do not remove the `&storageClassName` anchor! |
 
 ### Prowlarr

--- a/servarr/README.md
+++ b/servarr/README.md
@@ -62,7 +62,7 @@ Servarr complete Helm Chart for Kubernetes
 |-----|------|---------|-------------|
 | global.apikey | string | No default value is configured for security reasons | Insert your Prowlarr, Sonarr, Radarr API key here (one to rule them all!). Do not remove the `&apikey` anchor! |
 | global.certManagerClusterIssuer | string | No default value, leave empty if not required | Insert your cert manager cluster issuer, e.g.: letsencrypt-cloudflare. Do not remove the `&issuer` anchor! |
-| global.ingressClassName | string | nginx | Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor! |
+| global.ingressClassName | string | nginx | Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor, and do not leave the anchor value empty, otherwise you will face a `null` value error! |
 | global.storageClassName | string | `"network-block"` | Insert your storage class here, e.g.: &storageClassName network-block. Do not remove the `&storageClassName` anchor! |
 
 ### Prowlarr

--- a/servarr/values.yaml
+++ b/servarr/values.yaml
@@ -6,6 +6,10 @@ global:
   # -- (string) Insert your storage class here, e.g.: &storageClassName network-block. Do not remove the `&storageClassName` anchor!
   # @section -- Global
   storageClassName: &storageClassName "network-block"
+  # -- (string) Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor!
+  # @default -- No default value, leave empty to use the default Ingress Class.
+  # @section -- Global
+  ingressClassName: &ingressClassName
   # -- (string) Insert your cert manager cluster issuer, e.g.: letsencrypt-cloudflare. Do not remove the `&issuer` anchor!
   # @default -- No default value, leave empty if not required
   # @section -- Global
@@ -467,7 +471,7 @@ issuer:
   # @section -- Issuer
   secretName: letsencrypt-prod
   # @section -- Issuer
-  ingressClassName: nginx
+  ingressClassName: *ingressClassName
   # -- Insert your CloudFlare key
   # @section -- Issuer
   cloudFlareKey:
@@ -530,7 +534,7 @@ sonarr:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: sonarr.local
           paths:
@@ -604,7 +608,7 @@ radarr:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: radarr.local
           paths:
@@ -699,7 +703,7 @@ jellyfin:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: jellyfin.local
           paths:
@@ -787,7 +791,7 @@ jellyseerr:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: jellyseerr.local
           paths:
@@ -852,7 +856,7 @@ qbittorrent:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: torrent.local
           paths:
@@ -910,7 +914,7 @@ prowlarr:
       expandObjectName: false
       annotations:
         cert-manager.io/cluster-issuer: *issuer
-      ingressClassName: "nginx"
+      ingressClassName: *ingressClassName
       hosts:
         - host: prowlarr.local
           paths:

--- a/servarr/values.yaml
+++ b/servarr/values.yaml
@@ -7,9 +7,9 @@ global:
   # @section -- Global
   storageClassName: &storageClassName "network-block"
   # -- (string) Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor!
-  # @default -- No default value, leave empty to use the default Ingress Class.
+  # @default -- nginx
   # @section -- Global
-  ingressClassName: &ingressClassName
+  ingressClassName: &ingressClassName "nginx"
   # -- (string) Insert your cert manager cluster issuer, e.g.: letsencrypt-cloudflare. Do not remove the `&issuer` anchor!
   # @default -- No default value, leave empty if not required
   # @section -- Global

--- a/servarr/values.yaml
+++ b/servarr/values.yaml
@@ -6,7 +6,7 @@ global:
   # -- (string) Insert your storage class here, e.g.: &storageClassName network-block. Do not remove the `&storageClassName` anchor!
   # @section -- Global
   storageClassName: &storageClassName "network-block"
-  # -- (string) Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor!
+  # -- (string) Insert your ingress class here, e.g.: &ingressClassName nginx. Do not remove the `&ingressCassName` anchor, and do not leave the anchor value empty, otherwise you will face a `null` value error!
   # @default -- nginx
   # @section -- Global
   ingressClassName: &ingressClassName "nginx"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

There's a new `global.ingressClassName` parameter that can be used to change the Ingress Class.

* **What is the current behavior?** (You can also link to an open issue here)

The Ingress Class is set all around the values with the default value `nginx`.

* **What is the new behavior (if this is a feature change)?**

New global parameter `global.ingressClassName` that makes use of YAML anchors to spread it all around the Chart.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

None