### PR TITLE
Add a pipeline to manage stale issues/PRs

### DIFF
--- a/.github/ci/stale-detector-bot.yaml
+++ b/.github/ci/stale-detector-bot.yaml
@@ -1,0 +1,22 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v9
+      with:
+        stale-issue-label: 'stale'
+        close-issue-label: 'dead'
+        stale-pr-label: 'stale'
+        close-pr-label: 'dead'
+        stale-issue-message: 'This issue has been marked as stale because it has been open for 30 days with no activity. This thread will be automatically closed in 7 days if no further activity occurs.'
+        stale-pr-message: 'This pull request has been marked as stale because it has been open for 30 days with no activity. This thread will be automatically closed in 7 days if no further activity occurs.'
+        close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+        close-pr-message: 'This pull request was closed because it has been stalled for 7 days with no activity.'
+        exempt-issue-labels: 'keep open'
+        exempt-pr-labels: 'keep open'
+        days-before-stale: 30
+        days-before-close: 7


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The branch naming convention follows our guidelines
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A new workflow that will perform the Issues/PRs lifecycle management.

* **What is the current behavior?** (You can also link to an open issue here)

The issues/PRs must be manually checked and closed if they are stale.

* **What is the new behavior (if this is a feature change)?**

The workflow will check every midnight for stale issues/pull requests and will:

- Apply a stale label to the item
- Comment the item with an automatic message to notify that the item is stale

An issue/pull requests is "stale" after 30 days with no activity. If the item stays stale, it will be automatically closed after 7 days.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

None