### PR TITLE
Add Helm annotations for ArtifactHub integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/servarr)](https://artifacthub.io/packages/search?repo=servarr)
+
 # Servarr
 
 This project is a complete Servarr Helm Chart that includes also Sonarr, Radarr, Prowlarr, qBitTorrent, Jellyseerr, Jellyfin and Flaresovlerr as sub-charts.

--- a/servarr/Chart.yaml
+++ b/servarr/Chart.yaml
@@ -43,6 +43,13 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/license: AGPL-3.0-or-later
   artifacthub.io/prerelease: "false"
+  artifacthub.io/maintainers: |
+    - name: imgios
+      email: g.sulipano@outlook.it
+    - name: mrgions
+      email: g.pasquariello96@gmail.com
+    - name: lucaam
+      email: luca.amoriello@hotmail.it
 maintainers:
   - name: Alfonso De Masi
     email: adm220297@proton.me

--- a/servarr/Chart.yaml
+++ b/servarr/Chart.yaml
@@ -44,9 +44,11 @@ annotations:
   artifacthub.io/license: AGPL-3.0-or-later
   artifacthub.io/prerelease: "false"
   artifacthub.io/maintainers: |
+    - name: fonzdm
+      email: adm220297@proton.me
     - name: imgios
       email: g.sulipano@outlook.it
-    - name: mrgions
+    - name: mrgionsi
       email: g.pasquariello96@gmail.com
     - name: lucaam
       email: luca.amoriello@hotmail.it

--- a/servarr/Chart.yaml
+++ b/servarr/Chart.yaml
@@ -38,7 +38,11 @@ dependencies:
   - name: flaresolverr
     version: "13.4.1"
     repository: "https://charts.truecharts.org"
-
+annotations:
+  artifacthub.io/alternativeName: servar
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/license: AGPL-3.0-or-later
+  artifacthub.io/prerelease: "false"
 maintainers:
   - name: Alfonso De Masi
     email: adm220297@proton.me


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Enhancement.

* **What is the current behavior?** (You can also link to an open issue here)

Artifacthub page is not displayuing all the servarr chart informations.

* **What is the new behavior (if this is a feature change)?**

[Artifacthub page ](https://artifacthub.io/packages/helm/servarr/servarr) displays all additional information about the helm chart.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

> - #37 
> - #38 

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/fonzdm/servarr/CONTRIBUTING.md) -->
