### PR TITLE
use h4 instead of unordered list

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,24 @@
-* **Please check if the PR fulfills these requirements**
+#### **Please check if the PR fulfills these requirements**
 - [ ] The branch naming convention follows our guidelines
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+#### **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 
 <placeholder>
 
-* **What is the current behavior?** (You can also link to an open issue here)
+#### **What is the current behavior?** (You can also link to an open issue here)
 
 <placeholder>
 
-* **What is the new behavior (if this is a feature change)?**
+#### **What is the new behavior (if this is a feature change)?**
 
 <placeholder>
 
-* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+#### **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 
 <placeholder>
 
-* **Other information**:
+#### **Other information**:
 
 <placeholder>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,24 @@
-#### **Please check if the PR fulfills these requirements**
+#### Please check if the PR fulfills these requirements
 - [ ] The branch naming convention follows our guidelines
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-#### **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
 
 <placeholder>
 
-#### **What is the current behavior?** (You can also link to an open issue here)
+#### What is the current behavior? (You can also link to an open issue here)
 
 <placeholder>
 
-#### **What is the new behavior (if this is a feature change)?**
+#### What is the new behavior (if this is a feature change)?
 
 <placeholder>
 
-#### **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
 
 <placeholder>
 
-#### **Other information**:
+#### Other information:
 
 <placeholder>
 


### PR DESCRIPTION
#### **Please check if the PR fulfills these requirements**
- [x] The branch naming convention follows our guidelines
- [ ] Docs have been added / updated (for bug fixes / features)

#### **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Enhancement

#### **What is the current behavior?** (You can also link to an open issue here)

The pull request template currently used relies on unordered list items for each section, and this makes writing a PR a bit messy when using lists in those sections.

#### **What is the new behavior (if this is a feature change)?**

Unordered list items are being replaced with H4, an example is the following PR written using the new template.

The following list is an example:

- item 1
- item 2
  1. subitem
  2. subitem
  3. subitem
- item 3

#### **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

None

#### **Other information**:

None