### PR TITLE
Split lint and build actions in two different pipelines

### DIFF
--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -1,0 +1,33 @@
+name: Helm Chart Build
+
+on:
+  push:
+    branches:
+      - 'dev'
+  pull_request:
+    branches:
+      - 'dev'
+      - 'main'
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.1.0
+
+      - name: Helm Dependency update
+        run: helm dependency update servarr/ --debug
+
+      - name: Helm Template
+        run: helm template servarr servarr/ --debug -f .github/ci/ci-values.yaml
+
+      - name: Create Package
+        run: helm package servarr/

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -1,4 +1,4 @@
-name: Helm Chart Lint & Build
+name: Helm Chart Lint
 
 on:
   push:
@@ -36,25 +36,3 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false
-
-  build:
-    name: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4.1.0
-
-      - name: Helm Dependency update
-        run: helm dependency update servarr/ --debug
-
-      - name: Helm Template
-        run: helm template servarr servarr/ --debug -f .github/ci/ci-values.yaml
-
-      - name: Create Package
-        run: helm package servarr/


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [ ] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Refactoring

#### What is the current behavior? (You can also link to an open issue here)

Both Chart lint and build are happening in the same pipeline.

#### What is the new behavior (if this is a feature change)?

Chart lint and build happens in two different pipelines, in this way the pipeline structure should be be cleaner since there aren't dependency between the two actions.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Nope

#### Other information:

None

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/fonzdm/servarr/CONTRIBUTING.md) -->
