### PR TITLE
Introduce cache usage in both build and lint pipeline

### DIFF
--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: servarr/charts
-          key: ${{ runner.os }}-dep-charts
+          key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Helm Dependency update
         if: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: servarr/charts
-          key: ${{ runner.os }}-dep-charts # ${{ steps.cache-primes-restore.outputs.cache-primary-key }}
+          key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Helm Template
         run: helm template servarr servarr/ --debug -f .github/ci/ci-values.yaml

--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -29,7 +29,9 @@ jobs:
         id: cache-charts
         uses: actions/cache/restore@v4
         with:
-          path: servarr/charts
+          path: |
+            servarr/charts
+            Chart.lock
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Helm Dependency update
@@ -41,7 +43,9 @@ jobs:
         id: cache-charts-save
         uses: actions/cache/save@v4
         with:
-          path: servarr/charts
+          path: |
+            servarr/charts
+            Chart.lock
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Helm Template

--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: |
             servarr/charts
-            Chart.lock
+            servarr/Chart.lock
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Helm Dependency update
@@ -45,7 +45,7 @@ jobs:
         with:
           path: |
             servarr/charts
-            Chart.lock
+            servarr/Chart.lock
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Helm Template

--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -29,9 +29,7 @@ jobs:
         id: cache-charts
         uses: actions/cache/restore@v4
         with:
-          path: |
-            servarr/charts
-            servarr/Chart.lock
+          path: servarr/charts
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Helm Dependency update
@@ -43,9 +41,7 @@ jobs:
         id: cache-charts-save
         uses: actions/cache/save@v4
         with:
-          path: |
-            servarr/charts
-            servarr/Chart.lock
+          path: servarr/charts
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Helm Template

--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - 'dev'
       - 'main'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'dev'
-      - 'ci/cache-usage'
+      - 'ci/cache-usage' # test-purposes
   pull_request:
     branches:
       - 'dev'

--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - 'dev'
-      - 'ci/cache-usage' # test-purposes
   pull_request:
     branches:
       - 'dev'
       - 'main'
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -22,9 +22,25 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4.1.0
+      
+      - name: Fetch cached dependencies charts
+        id: cache-charts
+        uses: actions/cache/restore@v4
+        with:
+          path: servarr/charts
+          key: ${{ runner.os }}-dep-charts
 
       - name: Helm Dependency update
+        if: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}
         run: helm dependency update servarr/ --debug
+      
+      - name: Save dependencies charts in the cache
+        if: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}
+        id: cache-charts-save
+        uses: actions/cache/save@v4
+        with:
+          path: servarr/charts
+          key: ${{ runner.os }}-dep-charts # ${{ steps.cache-primes-restore.outputs.cache-primary-key }}
 
       - name: Helm Template
         run: helm template servarr servarr/ --debug -f .github/ci/ci-values.yaml

--- a/.github/workflows/chart-build.yaml
+++ b/.github/workflows/chart-build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'dev'
+      - 'ci/cache-usage'
   pull_request:
     branches:
       - 'dev'

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -49,7 +49,7 @@ jobs:
         run: ls -halF servarr/charts
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false --helm-dependency-extra-args ["--skip-refresh"]
+        run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false --helm-dependency-extra-args "--skip-refresh"
 
       - name: Save dependencies charts in the cache
         if: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -39,8 +39,10 @@ jobs:
         id: cache-charts
         uses: actions/cache/restore@v4
         with:
-          path: servarr/charts
-          key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
+          path: |
+            servarr/charts
+            Chart.lock
+          key: dep-charts-${{ hashFiles('servarr/Chart.lock') }}
 
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false
@@ -50,5 +52,7 @@ jobs:
         id: cache-charts-save
         uses: actions/cache/save@v4
         with:
-          path: servarr/charts
+          path: |
+            servarr/charts
+            Chart.lock
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -49,7 +49,7 @@ jobs:
         run: ls -halF servarr/charts
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false
+        run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false --helm-dependency-extra-args ["--skip-refresh"]
 
       - name: Save dependencies charts in the cache
         if: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.x
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v3.12.0
 
       - name: Fetch cached dependencies charts
         id: cache-charts

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -42,7 +42,7 @@ jobs:
           path: |
             servarr/charts
             servarr/Chart.lock
-          key: dep-charts-${{ hashFiles('servarr/Chart.lock') }}
+          key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         env:
-          CACHE_HIT: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}
+          CACHE_HIT: ${{ steps.cache-charts.outputs.cache-hit == 'true' }}
         run: |
           extraArgs=""
           if [[ "$CACHE_HIT" == "true" ]] ; then

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -1,14 +1,9 @@
 name: Helm Chart Lint
 
 on:
-  push:
-    branches:
-      - 'dev'
-      - 'ci/cache-usage' # test-purposes
-  pull_request:
-    branches:
-      - 'dev'
-      - 'main'
+  workflow_run:
+    workflows: [Helm Chart Build]
+    types: [completed]
 
 jobs:
   lint:

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -42,6 +42,9 @@ jobs:
           path: servarr/charts
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
+      - name: Check servarr/ content
+        run: ls -halF servarr
+
       - name: Check /charts content
         run: ls -halF servarr/charts
 

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.x
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v3.12.0
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Fetch cached dependencies charts
         id: cache-charts

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: |
             servarr/charts
-            Chart.lock
+            servarr/Chart.lock
           key: dep-charts-${{ hashFiles('servarr/Chart.lock') }}
 
       - name: Run chart-testing (lint)
@@ -54,5 +54,5 @@ jobs:
         with:
           path: |
             servarr/charts
-            Chart.lock
+            servarr/Chart.lock
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'dev'
+      - 'ci/cache-usage' # test-purposes
   pull_request:
     branches:
       - 'dev'

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -39,9 +39,7 @@ jobs:
         id: cache-charts
         uses: actions/cache/restore@v4
         with:
-          path: |
-            servarr/charts
-            servarr/Chart.lock
+          path: servarr/charts
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
       - name: Run chart-testing (lint)
@@ -52,7 +50,5 @@ jobs:
         id: cache-charts-save
         uses: actions/cache/save@v4
         with:
-          path: |
-            servarr/charts
-            servarr/Chart.lock
+          path: servarr/charts
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -34,5 +34,20 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
 
+      - name: Fetch cached dependencies charts
+        id: cache-charts
+        uses: actions/cache/restore@v4
+        with:
+          path: servarr/charts
+          key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
+
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false
+
+      - name: Save dependencies charts in the cache
+        if: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}
+        id: cache-charts-save
+        uses: actions/cache/save@v4
+        with:
+          path: servarr/charts
+          key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -37,12 +37,6 @@ jobs:
           path: servarr/charts
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
-      - name: Check servarr/ content
-        run: ls -halF servarr
-
-      - name: Check /charts content
-        run: ls -halF servarr/charts
-
       - name: Run chart-testing (lint)
         env:
           CACHE_HIT: ${{ steps.cache-charts.outputs.cache-hit == 'true' }}
@@ -51,8 +45,6 @@ jobs:
           if [[ "$CACHE_HIT" == "true" ]] ; then
             extraArgs="--skip-helm-dependencies"
           fi
-          echo "debug: $CACHE_HIT"
-          echo "debug: $extraArgs"
           ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false $extraArgs
 
       - name: Save dependencies charts in the cache

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -4,6 +4,9 @@ on:
   workflow_run:
     workflows: [Helm Chart Build]
     types: [completed]
+    branches:
+      - dev
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -49,7 +49,16 @@ jobs:
         run: ls -halF servarr/charts
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false
+        env:
+          CACHE_HIT: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}
+        run: |
+          extraArgs=""
+          if [[ "$CACHE_HIT" == "true" ]] ; then
+            extraArgs="--skip-helm-dependencies"
+          fi
+          echo "debug: $CACHE_HIT"
+          echo "debug: $extraArgs"
+          ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false $extraArgs
 
       - name: Save dependencies charts in the cache
         if: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -49,7 +49,7 @@ jobs:
         run: ls -halF servarr/charts
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false --helm-dependency-extra-args "--skip-refresh"
+        run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false
 
       - name: Save dependencies charts in the cache
         if: ${{ steps.cache-charts.outputs.cache-hit != 'true' }}

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -42,6 +42,9 @@ jobs:
           path: servarr/charts
           key: dep-charts-${{ hashFiles('servarr/Chart.yaml') }}
 
+      - name: Check /charts content
+        run: ls -halF servarr/charts
+
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs=servarr/ --charts=servarr/ --validate-maintainers=false
 


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

CI pipelines changes

#### What is the current behavior? (You can also link to an open issue here)

Both build and lint workflows ain't using any cache mechanism and this leads to both of them trying to fetch the dependencies from Quay.io, but both fails because the Quay.io's limitations.

#### What is the new behavior (if this is a feature change)?

Introduced the cache in both build and lint pipeline. In the build workflow, we first check for the cache and then we skip the `helm dependency update` if we have a cache hit. In the lint workflow, similar to the build one, we first check for the cache and then we perform the lint with an additional flag (`--skip-helm-dependencies`) if we have a cache hit.

The cache key is based on the `servarr/Chart.yaml` hash and this means that any changes to the file (version bump included) should trigger a new cache creation.

See #68 

Moreover, changed the lint pipeline execution rules to being triggered only after the build pipeline completed.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

#### Other information:

No.

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/fonzdm/servarr/CONTRIBUTING.md) -->
