### PR TITLE
Revert Helm Lint workflow rule

### DIFF
--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -1,12 +1,13 @@
 name: Helm Chart Lint
 
 on:
-  workflow_run:
-    workflows: [Helm Chart Build]
-    types: [completed]
+  push:
     branches:
-      - dev
-      - main
+      - 'dev'
+  pull_request:
+    branches:
+      - 'dev'
+      - 'main'
 
 jobs:
   lint:


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [X] The branch naming convention follows our guidelines
- [X] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

CI Fix

#### What is the current behavior? (You can also link to an open issue here)

Helm lint workflow does not run upon PR.
It's invoked directly on the main branch, meaning it checks out the repo at the main branch.

#### What is the new behavior (if this is a feature change)?

Helm lint workflow is run independently from the Helm build workflow and the original ruleset is restored.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

#### Other information:

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/fonzdm/servarr/CONTRIBUTING.md) -->
