### PR TITLE
Fix services resolution in init jobs

### DIFF
--- a/servarr/Chart.yaml
+++ b/servarr/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: servarr
 description: Servarr complete Helm Chart for Kubernetes
 type: application
-version: 1.0.1
-appVersion: "1.0.0"
+version: 1.0.2
+appVersion: "1.0.2"
 keywords:
   - servarr
   - prowlarr

--- a/servarr/README.md
+++ b/servarr/README.md
@@ -2,7 +2,7 @@
 
 
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square) 
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.2](https://img.shields.io/badge/AppVersion-1.0.2-informational?style=flat-square) 
 
 Servarr complete Helm Chart for Kubernetes
 

--- a/servarr/templates/init-jellyfin.yaml
+++ b/servarr/templates/init-jellyfin.yaml
@@ -26,7 +26,7 @@ spec:
             [
               "sh",
               "-c",
-              "until curl  \"http://{{ .Release.Namespace }}-jellyfin.{{ .Release.Namespace }}.svc.cluster.local:8096\"; do echo waiting for servarr-jellyfin; sleep 5; done;sleep 10;",
+              "until curl  \"http://{{ .Release.Name }}-jellyfin.{{ .Release.Namespace }}.svc.cluster.local:8096\"; do echo waiting for servarr-jellyfin; sleep 5; done;sleep 10;",
             ]
       containers:
       - name: initialize-jellyfin
@@ -36,7 +36,7 @@ spec:
           - name: PYTHONUNBUFFERED
             value: "1"
           - name: JELLYFIN_HOST
-            value: "{{ .Release.Namespace }}-jellyfin.{{ .Release.Namespace }}.svc.cluster.local:8096"
+            value: "{{ .Release.Name }}-jellyfin.{{ .Release.Namespace }}.svc.cluster.local:8096"
           - name: JELLYFIN_USERNAME
             value: "{{ $.Values.dash.username }}"
           - name: JELLYFIN_PASSWORD

--- a/servarr/templates/init-jellyseerr.yaml
+++ b/servarr/templates/init-jellyseerr.yaml
@@ -26,7 +26,7 @@ spec:
           command:
             - "sh"
             - "-c"
-            - "until curl \"http://{{ .Release.Namespace }}-jellyseerr.{{ .Release.Namespace }}.svc.cluster.local:10241\"; do echo waiting for servarr-jellyseerr; sleep 5; done;sleep 10;"
+            - "until curl \"http://{{ .Release.Name }}-jellyseerr.{{ .Release.Namespace }}.svc.cluster.local:10241\"; do echo waiting for servarr-jellyseerr; sleep 5; done;sleep 10;"
       containers:
       - name: initialize-jellyseer
         image: "nyurik/alpine-python3-requests"
@@ -35,11 +35,11 @@ spec:
           - name: PYTHONUNBUFFERED
             value: "1"
           - name: JELLYSEERR_HOST
-            value: "{{ .Release.Namespace }}-jellyseerr.{{ .Release.Namespace }}.svc.cluster.local"
+            value: "{{ .Release.Name }}-jellyseerr.{{ .Release.Namespace }}.svc.cluster.local"
           - name: JELLYSEERR_PORT
             value: "10241"
           - name: JELLYFIN_HOST
-            value: "{{ .Release.Namespace }}-jellyfin"
+            value: "{{ .Release.Name }}-jellyfin"
           - name: JELLYFIN_PORT
             value: "8096"
           - name: JELLYFIN_USERNAME

--- a/servarr/templates/init-prowlarr.yaml
+++ b/servarr/templates/init-prowlarr.yaml
@@ -26,7 +26,7 @@ spec:
             [
               "sh",
               "-c",
-              "until curl  \"http://{{ .Release.Namespace }}-prowlarr.{{ .Release.Namespace }}.svc.cluster.local:9696\"; do echo waiting for servarr-prowlarr; sleep 5; done;",
+              "until curl  \"http://{{ .Release.Name }}-prowlarr.{{ .Release.Namespace }}.svc.cluster.local:9696\"; do echo waiting for servarr-prowlarr; sleep 5; done;",
             ]
       containers:
       - name: initialize-prowlarr
@@ -36,23 +36,23 @@ spec:
           - name: PYTHONUNBUFFERED
             value: "1"
           - name: PROWLARR_HOST
-            value: "{{ .Release.Namespace }}-prowlarr.{{ .Release.Namespace }}.svc.cluster.local:9696"
+            value: "{{ .Release.Name }}-prowlarr.{{ .Release.Namespace }}.svc.cluster.local:9696"
           - name: API_KEY
             value: "{{ $.Values.global.apikey }}"
           - name: TORRENT_SERVICE
-            value: "{{ .Release.Namespace }}-qbittorrent"
+            value: "{{ .Release.Name }}-qbittorrent"
           - name: TORRENT_ADMIN
             value: "{{ $.Values.torrent.username }}"
           - name: TORRENT_PASSWORD
             value: "{{ $.Values.torrent.password }}"
           - name: PROWLARR_SERVICE
-            value: "{{ .Release.Namespace }}-prowlarr:9696"
+            value: "{{ .Release.Name }}-prowlarr:9696"
           - name: RADARR_SERVICE
-            value: "{{ .Release.Namespace }}-radarr:7878"
+            value: "{{ .Release.Name }}-radarr:7878"
           - name: FLARESOLVERR_SERVICE
-            value: "{{ .Release.Namespace }}-flaresolverr:8191"
+            value: "{{ .Release.Name }}-flaresolverr:8191"
           - name: SONARR_SERVICE
-            value: "{{ .Release.Namespace }}-sonarr:8989"
+            value: "{{ .Release.Name }}-sonarr:8989"
         command:
           - "/bin/sh"
           - "-ec"

--- a/servarr/templates/init-radarr.yaml
+++ b/servarr/templates/init-radarr.yaml
@@ -26,7 +26,7 @@ spec:
             [
               "sh",
               "-c",
-              "until curl  \"http://{{ .Release.Namespace }}-radarr.{{ .Release.Namespace }}.svc.cluster.local:7878\"; do echo waiting for servarr-radarr; sleep 5; done;",
+              "until curl  \"http://{{ .Release.Name }}-radarr.{{ .Release.Namespace }}.svc.cluster.local:7878\"; do echo waiting for servarr-radarr; sleep 5; done;",
             ]
       containers:
       - name: initialize-radarr
@@ -36,11 +36,11 @@ spec:
           - name: PYTHONUNBUFFERED
             value: "1"
           - name: RADARR_HOST
-            value: "{{ .Release.Namespace }}-radarr.{{ .Release.Namespace }}.svc.cluster.local:7878"
+            value: "{{ .Release.Name }}-radarr.{{ .Release.Namespace }}.svc.cluster.local:7878"
           - name: API_KEY
             value: "{{ $.Values.global.apikey }}"
           - name: TORRENT_SERVICE
-            value: "{{ .Release.Namespace }}-qbittorrent"
+            value: "{{ .Release.Name }}-qbittorrent"
           - name: TORRENT_ADMIN
             value: "{{ $.Values.torrent.username }}"
           - name: TORRENT_PASSWORD

--- a/servarr/templates/init-sonarr.yaml
+++ b/servarr/templates/init-sonarr.yaml
@@ -26,7 +26,7 @@ spec:
             [
               "sh",
               "-c",
-              "until curl  \"http://{{ .Release.Namespace }}-sonarr.{{ .Release.Namespace }}.svc.cluster.local:8989\"; do echo waiting for servarr-sonarr; sleep 5; done;",
+              "until curl  \"http://{{ .Release.Name }}-sonarr.{{ .Release.Namespace }}.svc.cluster.local:8989\"; do echo waiting for servarr-sonarr; sleep 5; done;",
             ]
       containers:
       - name: initialize-sonarr
@@ -36,11 +36,11 @@ spec:
           - name: PYTHONUNBUFFERED
             value: "1"
           - name: SONARR_HOST
-            value: "{{ .Release.Namespace }}-sonarr.{{ .Release.Namespace }}.svc.cluster.local:8989"
+            value: "{{ .Release.Name }}-sonarr.{{ .Release.Namespace }}.svc.cluster.local:8989"
           - name: API_KEY
             value: "{{ $.Values.global.apikey }}"
           - name: TORRENT_SERVICE
-            value: "{{ .Release.Namespace }}-qbittorrent"
+            value: "{{ .Release.Name }}-qbittorrent"
           - name: TORRENT_ADMIN
             value: "{{ $.Values.torrent.username }}"
           - name: TORRENT_PASSWORD


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Hotfix

#### What is the current behavior? (You can also link to an open issue here)

Servarr deployment fails with a release name that's not `servarr`, cause init jobs are trying to reach the services using the pattern `{{ .Release.Namespace }}-<service-name>`.

See more in #71 

#### What is the new behavior?

The init jobs will now correctly resolve the services name with the right pattern `{{ .Release.Name }}-<service-name>`

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

#### Other information:

No

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/fonzdm/servarr/CONTRIBUTING.md) -->
